### PR TITLE
Fix env validation in backend config

### DIFF
--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -48,7 +48,7 @@ const config: Config = {
   jwtSecret: process.env.JWT_SECRET || 'your-secret-key',
 
   // Database
-  databaseUrl: process.env.DATABASE_URL || '',
+  databaseUrl: process.env.DATABASE_URL || 'file:./dev.db',
   redisUrl: process.env.REDIS_URL || 'redis://localhost:6379',
 
   // External APIs
@@ -79,11 +79,11 @@ const config: Config = {
   logFile: process.env.LOG_FILE || 'logs/app.log',
 };
 
-// Validate required configuration
+// Validate required configuration but don't exit during tests
 const requiredEnvVars = ['DATABASE_URL'];
 const missingEnvVars = requiredEnvVars.filter(envVar => !process.env[envVar]);
 
-if (missingEnvVars.length > 0) {
+if (missingEnvVars.length > 0 && process.env.NODE_ENV !== 'test') {
   console.error('Missing required environment variables:', missingEnvVars);
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- allow backend tests to run without DATABASE_URL
- skip required env variable check during tests

## Testing
- `npm test` *(fails: TypeError and TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a4ffb0cc88332b33df4811b4083a1